### PR TITLE
Bugfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.jasperchasetoq</groupId>
     <artifactId>CompressionCraft</artifactId>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/me/jasperchasetoq/compressioncraft/implementation/machines/compressors/CcGemCompressor.java
+++ b/src/main/java/me/jasperchasetoq/compressioncraft/implementation/machines/compressors/CcGemCompressor.java
@@ -5,15 +5,24 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.machines.MachineProcessor;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.operations.CraftingOperation;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
+import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import me.jasperchasetoq.compressioncraft.CompressionCraftItems;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -57,7 +66,47 @@ public class CcGemCompressor extends AContainer implements RecipeDisplayItem {
 
         return displayRecipes;
     }
+    private static final int[] BORDER = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 13, 31, 36, 37, 38, 39, 40, 41, 42, 43, 44 };
+    private static final int[] BORDER_IN = { 9, 10, 11, 12, 18, 21, 27, 28, 29, 30 };
+    private static final int[] BORDER_OUT = { 14, 15, 16, 17, 23, 26, 32, 33, 34, 35 };
 
+    protected final List<MachineRecipe> recipes = new ArrayList<>();
+    private final MachineProcessor<CraftingOperation> processor = new MachineProcessor<>(this);
+    @Override
+    public MachineProcessor<CraftingOperation> getMachineProcessor() {
+        return processor;
+    }
+
+    protected void constructMenu(BlockMenuPreset preset) {
+        for (int i : BORDER) {
+            preset.addItem(i, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
+        }
+
+        for (int i : BORDER_IN) {
+            preset.addItem(i, ChestMenuUtils.getInputSlotTexture(), ChestMenuUtils.getEmptyClickHandler());
+        }
+
+        for (int i : BORDER_OUT) {
+            preset.addItem(i, ChestMenuUtils.getOutputSlotTexture(), ChestMenuUtils.getEmptyClickHandler());
+        }
+
+        preset.addItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+
+        for (int i : getOutputSlots()) {
+            preset.addMenuClickHandler(i, new ChestMenu.AdvancedMenuClickHandler() {
+
+                @Override
+                public boolean onClick(Player p, int slot, ItemStack cursor, ClickAction action) {
+                    return false;
+                }
+
+                @Override
+                public boolean onClick(InventoryClickEvent e, Player p, int slot, ItemStack cursor, ClickAction action) {
+                    return cursor == null || cursor.getType() == null || cursor.getType() == Material.AIR;
+                }
+            });
+        }
+    }
     @Override
     public ItemStack getProgressBar() {
         return new ItemStack(SlimefunItems.ELECTRIC_PRESS);

--- a/src/main/java/me/jasperchasetoq/compressioncraft/setup/CompressionCraftItemsSetup.java
+++ b/src/main/java/me/jasperchasetoq/compressioncraft/setup/CompressionCraftItemsSetup.java
@@ -77,47 +77,47 @@ public class CompressionCraftItemsSetup {
                         SlimefunItems.CARBON_PRESS, SlimefunItems.HEATING_COIL, SlimefunItems.CARBON_PRESS,
                 }).register(plugin);
         //Compressed Materials
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_COBBLESTONE_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_COBBLESTONE_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_STONE_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_STONE_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_FLINT_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_FLINT_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_GRAVEL_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_GRAVEL_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_CLAY_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_CLAY_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_COAL_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_COAL_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_COAL_BLOCK_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_COAL_BLOCK_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_IRON_NUGGET_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_IRON_NUGGET_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_IRON_INGOT_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_IRON_INGOT_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_IRON_BLOCk_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_IRON_BLOCk_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_GOLD_NUGGET_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_GOLD_NUGGET_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_GOLD_INGOT_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_GOLD_INGOT_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_GOLD_BLOCK_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_GOLD_BLOCK_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_REDSTONE_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_REDSTONE_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_REDSTONE_BLOCK_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_REDSTONE_BLOCK_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_LAPIS_LAZULI_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_LAPIS_LAZULI_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_LAPIS_BLOCK_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_LAPIS_BLOCK_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_DIAMOND_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_DIAMOND_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_DIAMOND_BLOCK_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_DIAMOND_BLOCK_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_EMERALD_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_EMERALD_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
-        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_EMERALD_BLOCK_1, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new SlimefunItem(CompressionCraftItems.CC_MATERIALS, CompressionCraftItems.CC_EMERALD_BLOCK_1, RecipeType.NULL,
                 new ItemStack[] {null, null, null, null, null, null, null, null, null,}).register(plugin);
 }
 }


### PR DESCRIPTION
fixed bug where compressed cobble would show up where the barrier is supposed to be after taking out a compressed item from the simple utils workbench

changelog:
-changed all crafting material items recipe from enhanced crafting table to null as it should have been in the first place